### PR TITLE
ci: set fail_ci_if_error to false for Codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         files: ./coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:


### PR DESCRIPTION
- Changed fail_ci_if_error from true to false
- Prevents CI failure when CODECOV_TOKEN is not configured
- Codecov upload will continue to run but won't block PR merges
- Fixes: 'Token required - not valid tokenless upload' error